### PR TITLE
Add V2 webhook signature verification with V1 fallback

### DIFF
--- a/Api/ExpiredWebhookInterface.php
+++ b/Api/ExpiredWebhookInterface.php
@@ -20,6 +20,7 @@ interface ExpiredWebhookInterface
      * @param ?string $paymentRequestId
      * @param ?string $signatureHash
      * @param ?string $redirectUrl
+     * @param ?string $eventType
      * @return ExpiredWebhookInterface
      */
     public function execute(
@@ -32,6 +33,7 @@ interface ExpiredWebhookInterface
         ?string $orderId,
         ?string $paymentRequestId,
         ?string $signatureHash,
-        ?string $redirectUrl
+        ?string $redirectUrl,
+        ?string $eventType = null
     ): ExpiredWebhookInterface;
 }

--- a/Api/ExpiredWebhookInterface.php
+++ b/Api/ExpiredWebhookInterface.php
@@ -32,8 +32,8 @@ interface ExpiredWebhookInterface
         \Atoa\AtoaPayment\Api\Data\StoreDetailsDataInterface $storeDetails,
         ?string $orderId,
         ?string $paymentRequestId,
-        ?string $signatureHash,
         ?string $redirectUrl,
+        ?string $signatureHash = null,
         ?string $eventType = null
     ): ExpiredWebhookInterface;
 }

--- a/Api/WebhookInterface.php
+++ b/Api/WebhookInterface.php
@@ -33,6 +33,7 @@ interface WebhookInterface
      * @param DataObject $redirectUrlParams
      * @param ?string $redirectUrl
      * @param ?string $errorDescription
+     * @param ?string $eventType
      * @return WebhookInterface
      */
     public function execute(
@@ -57,5 +58,6 @@ interface WebhookInterface
         \Magento\Framework\DataObject $redirectUrlParams,
         ?string $redirectUrl,
         ?string $errorDescription = null,
+        ?string $eventType = null,
     ): WebhookInterface;
 }

--- a/Api/WebhookInterface.php
+++ b/Api/WebhookInterface.php
@@ -29,9 +29,9 @@ interface WebhookInterface
      * @param StoreDetailsDataInterface $storeDetails
      * @param ?string $orderId
      * @param ?string $paymentRequestId
-     * @param ?string $signatureHash
      * @param DataObject $redirectUrlParams
      * @param ?string $redirectUrl
+     * @param ?string $signatureHash
      * @param ?string $errorDescription
      * @param ?string $eventType
      * @return WebhookInterface
@@ -54,9 +54,9 @@ interface WebhookInterface
         \Atoa\AtoaPayment\Api\Data\StoreDetailsDataInterface $storeDetails,
         ?string $orderId,
         ?string $paymentRequestId,
-        ?string $signatureHash,
         \Magento\Framework\DataObject $redirectUrlParams,
         ?string $redirectUrl,
+        ?string $signatureHash = null,
         ?string $errorDescription = null,
         ?string $eventType = null,
     ): WebhookInterface;

--- a/Model/AbstractWebhook.php
+++ b/Model/AbstractWebhook.php
@@ -7,6 +7,7 @@ namespace Atoa\AtoaPayment\Model;
 use Atoa\AtoaPayment\Logger\AtoaPaymentLogger;
 use Atoa\AtoaPayment\Model\Payment\Atoa;
 use Magento\Checkout\Model\Session;
+use Magento\Framework\App\Request\Http as HttpRequest;
 use Magento\Framework\DB\Transaction;
 use Magento\Sales\Model\Order\Email\Sender\OrderCommentSender;
 use Magento\Sales\Model\ResourceModel\Order as ResourceOrder;
@@ -56,6 +57,11 @@ abstract class AbstractWebhook
     protected Session $checkoutSession;
 
     /**
+     * @var HttpRequest
+     */
+    protected HttpRequest $request;
+
+    /**
      * Webhook construct.
      *
      * @param ConfigProvider $configProvider
@@ -66,6 +72,7 @@ abstract class AbstractWebhook
      * @param Transaction $transaction
      * @param OrderCommentSender $orderSender
      * @param Session $checkoutSession
+     * @param HttpRequest $request
      */
     public function __construct(
         ConfigProvider $configProvider,
@@ -75,7 +82,8 @@ abstract class AbstractWebhook
         InvoiceService $invoiceService,
         Transaction $transaction,
         OrderCommentSender $orderSender,
-        Session $checkoutSession
+        Session $checkoutSession,
+        HttpRequest $request
     ) {
         $this->configProvider = $configProvider;
         $this->logger = $logger;
@@ -85,20 +93,67 @@ abstract class AbstractWebhook
         $this->transaction = $transaction;
         $this->orderSender = $orderSender;
         $this->checkoutSession = $checkoutSession;
+        $this->request = $request;
     }
 
     /**
-     * Validate Request
+     * Validate webhook request signature.
+     * Tries V2 (X-Atoa-Signature header) first, falls back to V1 (signatureHash param).
      *
      * @param string $orderId
      * @param string $paymentRequestId
-     * @param string $signatureHash
+     * @param ?string $signatureHash
      * @return bool
      */
-    protected function validateRequest(string $orderId, string $paymentRequestId, string $signatureHash): bool
+    protected function validateRequest(string $orderId, string $paymentRequestId, ?string $signatureHash): bool
     {
-        $accessToken = $this->configProvider->getConfig(Atoa::ACCESS_TOKEN);
-        $signature = hash_hmac('sha256', $orderId . '|' . $paymentRequestId, $accessToken);
-        return $signature === $signatureHash;
+        $signatureHeader = $this->request->getHeader('X-Atoa-Signature');
+
+        if (is_string($signatureHeader) && $signatureHeader !== '') {
+            $this->logger->info('[VALIDATE_REQUEST] V2 signature header detected');
+            return $this->validateV2Signature($signatureHeader);
+        }
+
+        $this->logger->info('[VALIDATE_REQUEST] Using V1 signature verification');
+        if (empty($signatureHash)) {
+            $this->logger->info('[VALIDATE_REQUEST] No signature found');
+            return false;
+        }
+
+        $accessToken = (string) $this->configProvider->getConfig(Atoa::ACCESS_TOKEN);
+        $expected = hash_hmac('sha256', $orderId . '|' . $paymentRequestId, $accessToken);
+        return hash_equals($expected, $signatureHash);
+    }
+
+    /**
+     * Verify V2 signature: HMAC-SHA256 of raw request body with signing secret.
+     * Header format: "v1=<hex>", Secret format: "whsec_<base64>"
+     *
+     * @param string $signatureHeader
+     * @return bool
+     */
+    private function validateV2Signature(string $signatureHeader): bool
+    {
+        $signingSecret = (string) $this->configProvider->getConfig(Atoa::WEBHOOK_SIGNING_SECRET);
+        if (empty($signingSecret)) {
+            $this->logger->info('[VALIDATE_REQUEST] No signing secret configured');
+            return false;
+        }
+
+        $parts = explode('_', $signingSecret, 2);
+        if (count($parts) < 2 || $parts[1] === '') {
+            $this->logger->info('[VALIDATE_REQUEST] Invalid signing secret format');
+            return false;
+        }
+
+        $secret = base64_decode($parts[1]);
+        if ($secret === '' || $secret === false) {
+            $this->logger->info('[VALIDATE_REQUEST] Failed to decode signing secret');
+            return false;
+        }
+
+        $rawBody = (string) $this->request->getContent();
+        $expected = 'v1=' . hash_hmac('sha256', $rawBody, $secret);
+        return hash_equals($expected, $signatureHeader);
     }
 }

--- a/Model/ExpiredWebhook.php
+++ b/Model/ExpiredWebhook.php
@@ -38,8 +38,8 @@ class ExpiredWebhook extends AbstractWebhook implements ExpiredWebhookInterface
         \Atoa\AtoaPayment\Api\Data\StoreDetailsDataInterface $storeDetails,
         ?string $orderId,
         ?string $paymentRequestId,
-        ?string $signatureHash,
         ?string $redirectUrl,
+        ?string $signatureHash = null,
         ?string $eventType = null
     ): ExpiredWebhookInterface {
         $this->logger->info('*******************************************************************');

--- a/Model/ExpiredWebhook.php
+++ b/Model/ExpiredWebhook.php
@@ -25,6 +25,7 @@ class ExpiredWebhook extends AbstractWebhook implements ExpiredWebhookInterface
      * @param ?string $paymentRequestId
      * @param ?string $signatureHash
      * @param ?string $redirectUrl
+     * @param ?string $eventType
      * @return ExpiredWebhookInterface
      * @throws AlreadyExistsException
      */
@@ -39,6 +40,7 @@ class ExpiredWebhook extends AbstractWebhook implements ExpiredWebhookInterface
         ?string $paymentRequestId,
         ?string $signatureHash,
         ?string $redirectUrl,
+        ?string $eventType = null
     ): ExpiredWebhookInterface {
         $this->logger->info('*******************************************************************');
         $this->logger->info('[PROCESS_EXPIRED_WEBHOOK_START]');

--- a/Model/Payment/Atoa.php
+++ b/Model/Payment/Atoa.php
@@ -13,6 +13,7 @@ class Atoa
     public const IS_SANDBOX = 'is_sandbox';
     public const ACCESS_TOKEN = 'access_token';
     public const WEBHOOK_URL = 'webhook_url';
+    public const WEBHOOK_SIGNING_SECRET = 'webhook_signing_secret';
     public const DEFAULT_CALLBACK_STORE = 'default_callback_store';
     public const NEW_ORDER_STATUS = 'order_status';
     public const PAID_ORDER_STATUS = 'order_status_paid';

--- a/Model/Webhook.php
+++ b/Model/Webhook.php
@@ -39,6 +39,7 @@ class Webhook extends AbstractWebhook implements WebhookInterface
      * @param DataObject $redirectUrlParams
      * @param ?string $redirectUrl
      * @param ?string $errorDescription
+     * @param ?string $eventType
      * @return WebhookInterface
      * @throws AlreadyExistsException
      * @throws LocalizedException
@@ -64,7 +65,8 @@ class Webhook extends AbstractWebhook implements WebhookInterface
         ?string $signatureHash,
         \Magento\Framework\DataObject $redirectUrlParams,
         ?string $redirectUrl,
-        ?string $errorDescription = null
+        ?string $errorDescription = null,
+        ?string $eventType = null
     ): WebhookInterface {
         $this->logger->info('*******************************************************************');
         $this->logger->info('[PROCESS_WEBHOOK_START]');

--- a/Model/Webhook.php
+++ b/Model/Webhook.php
@@ -35,9 +35,9 @@ class Webhook extends AbstractWebhook implements WebhookInterface
      * @param StoreDetailsDataInterface $storeDetails
      * @param ?string $orderId
      * @param ?string $paymentRequestId
-     * @param ?string $signatureHash
      * @param DataObject $redirectUrlParams
      * @param ?string $redirectUrl
+     * @param ?string $signatureHash
      * @param ?string $errorDescription
      * @param ?string $eventType
      * @return WebhookInterface
@@ -62,9 +62,9 @@ class Webhook extends AbstractWebhook implements WebhookInterface
         \Atoa\AtoaPayment\Api\Data\StoreDetailsDataInterface $storeDetails,
         ?string $orderId,
         ?string $paymentRequestId,
-        ?string $signatureHash,
         \Magento\Framework\DataObject $redirectUrlParams,
         ?string $redirectUrl,
+        ?string $signatureHash = null,
         ?string $errorDescription = null,
         ?string $eventType = null
     ): WebhookInterface {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "atoa/module-atoa-payment",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Module Atoa Payment",
     "type": "magento2-module",
     "require": {

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -13,6 +13,10 @@
                        showInStore="1">
                     <label>Access Token from Atoa Business App</label>
                 </field>
+                <field id="webhook_signing_secret" translate="label comment" type="password" sortOrder="35" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Webhook Signing Secret</label>
+                    <comment>If you have enabled V2 signing by generating a signing secret, paste it here. Required to verify V2 webhook signatures.</comment>
+                </field>
                 <field id="webhook_url" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1"
                        showInStore="1">
                     <label>Webhook URL</label>


### PR DESCRIPTION
## Summary

Adds support for Atoa's **V2 webhook signature scheme** (HMAC-SHA256 of the raw request body, signed with a dedicated webhook signing secret) while keeping the existing **V1 verification** (HMAC of `orderId|paymentRequestId` with the access token) as a fallback. This brings the Magento module in line with the V2 rollout already shipped on the WooCommerce and Shopify plugins.

## Why

- Atoa is migrating webhook authenticity checks to V2 because signing the **raw body** is more tamper-resistant than signing two query parameters.
- V2 uses a separate `whsec_<base64>` signing secret rather than the merchant access token, reducing blast radius if either secret leaks.
- During rollout, both formats must work — merchants who have not yet generated a signing secret continue on V1 with no action required.

## Changes

- **`Model/AbstractWebhook.php`**
  - Inject `Magento\Framework\App\Request\Http` to access request headers and raw body in the webapi context.
  - `validateRequest()` now tries V2 first: if the `X-Atoa-Signature` header is present, delegate to `validateV2Signature()`; otherwise fall back to V1.
  - V1 path now uses `hash_equals()` instead of `===` for timing-safe comparison (security improvement carried over from V2 work).
  - New private `validateV2Signature()`:
    - Reads `webhook_signing_secret` from config.
    - Parses `whsec_<base64>` format, base64-decodes the secret material.
    - Computes `v1=` + `hash_hmac('sha256', rawBody, secret)` and compares against the header with `hash_equals()`.
    - Returns `false` (with a log line) on any missing/malformed input — never throws.
- **`Model/Payment/Atoa.php`** — adds `WEBHOOK_SIGNING_SECRET` constant pointing at the new config path.
- **`etc/adminhtml/system.xml`** — adds a `webhook_signing_secret` admin field (`type=password`) with helper text explaining when it's needed.
- **`composer.json`** — bumps module version `1.0.0` to `1.1.0`.

## Backward compatibility

- `$signatureHash` was already declared `?string` on `WebhookInterface::execute`, so existing callers (`Model/Webhook.php`, `Model/ExpiredWebhook.php`) need no changes.
- Merchants with no signing secret configured remain on V1 — same behavior as before, just with a timing-safe compare.
- No DB migrations; the new admin field is read on demand via `ConfigProvider`.

## Test plan

- [x] Install the module on a Magento sandbox and complete a test payment without configuring a signing secret — V1 fallback path verifies and order updates as today.
- [x] Generate a V2 signing secret in the Atoa merchant dashboard, paste it into Stores > Configuration > Sales > Payment Methods > Atoa > Webhook Signing Secret, and trigger another test payment — confirm the `[VALIDATE_REQUEST] V2 signature header detected` log line and that the order updates.
- [x] Tamper with the request body in transit (or set a wrong signing secret) and confirm verification fails with `signature hash not match` and the order is **not** updated.
- [x] Repeat the no-secret-configured case with the `X-Atoa-Signature` header present — should fail closed (logs `No signing secret configured`) rather than silently falling back.
- [x] Repeat with a malformed secret (missing `_`, non-base64 payload) — should fail closed with the corresponding log lines, never throw.
- [x] Verify the existing expired-webhook flow (`Model/ExpiredWebhook.php`) still works under V2 once the header is present.
