### PR TITLE
feat(phase-4): update webhook registration to dedicated integration route

### DIFF
--- a/Controller/Adminhtml/System/Config/GenerateWebhookUrl.php
+++ b/Controller/Adminhtml/System/Config/GenerateWebhookUrl.php
@@ -117,7 +117,7 @@ class GenerateWebhookUrl extends Action
                 return $result->setData([
                     'success' => false,
                     'url' => '',
-                    'message' => __($response['message'])
+                    'message' => __($responseWebhookExpired['message'])
                 ]);
             }
 

--- a/Controller/Adminhtml/System/Config/GenerateWebhookUrl.php
+++ b/Controller/Adminhtml/System/Config/GenerateWebhookUrl.php
@@ -16,7 +16,7 @@ use Magento\Store\Model\StoreManagerInterface;
 
 class GenerateWebhookUrl extends Action
 {
-    private const END_POINT = 'https://api.atoa.me/api/webhook/merchant';
+    private const END_POINT = 'https://api.atoa.me/api/webhook/integrations/magento';
 
     /**
      * @var CurlFactory

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "atoa/module-atoa-payment",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Module Atoa Payment",
     "type": "magento2-module",
     "require": {


### PR DESCRIPTION
## Summary

Updates the Magento admin webhook registration endpoint from the generic `POST /webhook/merchant` to the new dedicated integration route `POST /webhook/integrations/magento`. This allows the backend to assign `source = MAGENTO` server-side, keeping Magento endpoints isolated from merchant-managed DEFAULT endpoints and hidden from the dashboard webhook list. Also fixes a copy-paste bug in the expired webhook error handler.

Relates to: BUD-029

## Type of Change
- [x] Refactoring (endpoint URL change only — same request body, same response shape)
- [x] Bug fix (wrong response variable in expired webhook error handler)

## Changes

**`Controller/Adminhtml/System/Config/GenerateWebhookUrl.php`**
- Webhook registration URL changed from `webhook/merchant` to `webhook/integrations/magento`
- Request body unchanged: `{ url, event }`
- Two webhooks still registered: PAYMENTS_STATUS (`/rest/V1/atoa/webhook`) and EXPIRED_STATUS (`/rest/V1/atoa/expiredWebhook`)
- Response shape unchanged: `{ webhookId, url, event }` — backward compatible
- Fixed copy-paste bug: expired webhook error handler was reading `$response['message']` (the PAYMENTS_STATUS response variable) instead of `$responseWebhookExpired['message']`. This caused the wrong error message to be logged/returned when EXPIRED_STATUS webhook registration failed.

## Key Design Decisions

**Why a dedicated integration route?** On the shared `/webhook/merchant` route, the backend had to guess the source from URL pattern matching. A dedicated `/webhook/integrations/magento` route makes source unambiguous — set server-side regardless of URL content. Also prevents merchants from accidentally modifying Magento endpoints via the SDK or dashboard.

## Testing

**Verified**
- Magento admin generates webhook URL → `POST /api/webhook/integrations/magento` called ✓
- Both PAYMENTS_STATUS and EXPIRED_STATUS webhooks registered successfully ✓
- Response shape unchanged: `{webhookId, url, event}` ✓
- Registered endpoints have `source = MAGENTO` in DB ✓
- Magento endpoints not visible in merchant dashboard webhook list ✓
- Re-registering (store URL change) → existing endpoint URL updated, no duplicate created ✓
- EXPIRED_STATUS registration failure → correct error from `$responseWebhookExpired['message']` logged ✓

## Reviewer Checklist

- [ ] Only the URL path changed — request body and auth header handling are untouched
- [ ] Both webhook registrations (PAYMENTS_STATUS and EXPIRED_STATUS) use the new URL
- [ ] EXPIRED_STATUS error handler references `$responseWebhookExpired['message']`, not `$response['message']`

## Breaking Changes

None — response shape unchanged. ATOAWebhook must have the `/webhook/integrations/magento` route live before this is deployed.

## Deployment Order

Deploy **after AtoaWebhook PR #271**.