### PR TITLE
fix: correct response variable in expired webhook error handler

### DIFF
--- a/Controller/Adminhtml/System/Config/GenerateWebhookUrl.php
+++ b/Controller/Adminhtml/System/Config/GenerateWebhookUrl.php
@@ -117,7 +117,7 @@ class GenerateWebhookUrl extends Action
                 return $result->setData([
                     'success' => false,
                     'url' => '',
-                    'message' => __($response['message'])
+                    'message' => __($responseWebhookExpired['message'])
                 ]);
             }
 


### PR DESCRIPTION
## Summary

- Fixes a copy-paste bug in `GenerateWebhookUrl.php` where the expired webhook error handler was reading `$response['message']` instead of `$responseWebhookExpired['message']`, causing the wrong error message to be returned to the caller.

## Test plan
- [ ] Register a Magento webhook where the expired webhook registration fails
- [ ] Verify the error message returned is from the expired webhook response, not the first webhook response

🤖 Generated with [Claude Code](https://claude.com/claude-code)